### PR TITLE
Add documentation for radicale 2.0 proxy

### DIFF
--- a/radicale/Caddyfile
+++ b/radicale/Caddyfile
@@ -2,5 +2,7 @@ https://dav.example.org {
     proxy / localhost:5232/ {
         transparent
         header_upstream X-Script-Name /
+        # uncomment and adjust the following line if you want to serve radicale>2.0 in a path below "/"
+        # without /path_below
     }
 }

--- a/radicale/README.md
+++ b/radicale/README.md
@@ -12,4 +12,5 @@ Radicale will be available directly at https://dav.example.org/.
 
 If you want Radicale to be served at a path below `/`, you need to
 adjust the [`X-Script-Name`](https://radicale.org/proxy/) header in
-the [CaddyFile](./Caddyfile).
+the [CaddyFile](./Caddyfile) and since radicale V2.0 you need to 
+adjust the `without` rule as well.


### PR DESCRIPTION
Since radicale 2.0 we cannot set the root location in the radicale configuration file, so we have to remove it from the path sent upstream by caddy with the `without` rule.